### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, pep8
+envlist = py36, py37, py38, py39, py310, pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
* Use keyword argument for pytest.fixture
*  Remove deprecated loop argument being passed for Python 3.10 compatibility.

Fixes #7 