### PR TITLE
Drop test dependency on PyPI mock package; use unittest.mock instead

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,4 @@
 pytest>=2.6
 pytest-asyncio
 flake8
-mock
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ This test suite functions more as a sanity check than a comprehensive test.
 """
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 import asyncio
 


### PR DESCRIPTION
This dependency is not needed since it was only a backport from the Python 3.3+ standard library anyway.

See https://fedoraproject.org/wiki/Changes/DeprecatePythonMock for more details.